### PR TITLE
Pagination (#4) and Request Caching (#7)

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -30,9 +30,9 @@
       </div>
 
       <div class="d-flex flex-row justify-content-center btn-group">
-        <button class="btn btn-secondary" v-bind:class="{ disabled: previous == null }" v-on:click="changePage(previous)">Previous</button>
-        <button class="btn btn-secondary disabled">{{ page }}</button>
-        <button class="btn btn-secondary" v-bind:class="{ disabled: next == null }" v-on:click="changePage(next)">Next</button>
+        <button id="previousPage" class="btn btn-secondary" v-bind:class="{ disabled: previous == null }" v-on:click="changePage(previous)">Previous</button>
+        <button id="pageNumber" class="btn btn-secondary disabled">{{ page }}</button>
+        <button id="nextPage" class="btn btn-secondary" v-bind:class="{ disabled: next == null }" v-on:click="changePage(next)">Next</button>
       </div>
 
     </section>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -8,13 +8,13 @@
       <div class="d-flex flex-wrap">
         <router-link
           v-for="(person, id) in results"
-          :to="`/people/${id}`"
-          :key="id"
+          :to="`/people/${getIDFromPerson(person)}`"
+          :key="getIDFromPerson(person)"
           class="card m-2"
           style="width: 12rem;">
 
           <img
-            :src="`https://starwars-visualguide.com/assets/img/characters/${id + 1}.jpg`"
+            :src="`https://starwars-visualguide.com/assets/img/characters/${ getIDFromPerson(person) }.jpg`"
             class="card-img-top"
             alt="Card image cap">
 
@@ -27,6 +27,12 @@
           </div>
 
         </router-link>
+      </div>
+
+      <div class="d-flex flex-row justify-content-center btn-group">
+        <button class="btn btn-secondary" v-bind:class="{ disabled: previous == null }" v-on:click="changePage(previous)">Previous</button>
+        <button class="btn btn-secondary disabled">{{ page }}</button>
+        <button class="btn btn-secondary" v-bind:class="{ disabled: next == null }" v-on:click="changePage(next)">Next</button>
       </div>
 
     </section>
@@ -44,8 +50,31 @@ export default {
     await store.dispatch('people/list')
     next()
   },
+  methods: {
+    // Extract a value from a URL query string
+    getValFromURL(val, url) {
+      var vars = url.substring(url.indexOf('?') + 1).split("&");
+      for (var i = 0; i < vars.length; i++) {
+          var pair = vars[i].split("=");
+          if (pair[0] == val) {
+              return pair[1];
+          }
+      }
+    },
+    // Get the ID from a person using its URL value
+    getIDFromPerson(person) {
+      const regex = /people\/(\d+)/g;
+      return regex.exec(person.url)[1];
+    },
+    // Change the page given the URL for the next set of data
+    changePage(url) {
+      if(url) {
+        store.dispatch('people/list', this.getValFromURL("page", url));
+      }
+    }
+  },
   computed: {
-    ...mapState('people', ['results'])
+    ...mapState('people', ['results', 'page', 'next', 'previous'])
   }
 }
 </script>

--- a/src/store/people.js
+++ b/src/store/people.js
@@ -1,3 +1,5 @@
+import cachedFetch from '../util/cachedFetch'
+
 const initialState = () => ({
   page: 1,
   next: null,
@@ -28,7 +30,8 @@ export default {
     // This action takes state to use the current page as a default value
     async list ({ commit, state }, page = state.page) {
       // Fetch People from SWAPI and await the response.
-      const response = await fetch('https://swapi.co/api/people/?page=' + page)
+
+      const response = await cachedFetch('https://swapi.co/api/people/?page=' + page)
       if (response.ok) {
         // If the response is valid, parse the JSON string and commit the result
         commit('results', await response.json())

--- a/src/store/people.js
+++ b/src/store/people.js
@@ -1,4 +1,7 @@
 const initialState = () => ({
+  page: 1,
+  next: null,
+  previous: null,
   results: []
 })
 
@@ -11,19 +14,26 @@ export default {
   state: initialState,
   // https://vuex.vuejs.org/guide/mutations.html
   mutations: {
-    results: (state, results = []) => (state.results = results)
+    // Save results and next/previous links to the store
+    results: (state, response) => {
+      state.results = response.results
+      state.next = response.next
+      state.previous = response.previous
+    },
+    // Update the current page number
+    page: (state, page) => (state.page = page)
   },
   // https://vuex.vuejs.org/guide/actions.html
   actions: {
-    async list ({ commit }, page = 1) {
+    // This action takes state to use the current page as a default value
+    async list ({ commit, state }, page = state.page) {
       // Fetch People from SWAPI and await the response.
-      const response = await fetch('https://swapi.co/api/people')
-      // Parse the JSON string returned in the response into a JavaScript
-      // object and destructure the results property out of that object.
-      const { results } = await response.json()
+      const response = await fetch('https://swapi.co/api/people/?page=' + page)
       if (response.ok) {
-        // If the response is OK commit the data to the store.
-        commit('results', results)
+        // If the response is valid, parse the JSON string and commit the result
+        commit('results', await response.json())
+        // Commit the new page number
+        commit('page', page)
       } else {
         // If the response is not OK, log the response to the console.
         console.error(response)

--- a/src/util/cachedFetch.js
+++ b/src/util/cachedFetch.js
@@ -1,0 +1,51 @@
+/**
+ * Wrapper for the FetchAPI fetch() method that caches responses in
+ * sessionStorage and retrieves from the cache when the data hasn't reached its
+ * specified timeout
+ *
+ * Heavily inspired by https://www.sitepoint.com/cache-fetched-ajax-requests/
+ *
+ * url - fetch url
+ * init - options for fetch()
+ * timeout - optional timeout in minutes, defaults to 1 minute
+ */
+const cachedFetch = (url, init = {}, timeout = 1) => {
+  timeout *= 60
+
+  let cacheKey = url
+
+  // Fetch data and timeout from sessionStorage
+  let cachedData = sessionStorage.getItem(cacheKey)
+  let cacheTimeout = sessionStorage.getItem(cacheKey + 'time')
+
+  // If this request exists in the store, check if the data is past its timeout
+  if (cachedData !== null) {
+    if (cacheTimeout > Date.now()) {
+      // Return a Promise that resolves to a response containing the cached data
+      let response = new Response(new Blob([cachedData]))
+      return Promise.resolve(response)
+    } else {
+      // The response is too old, clean it up
+      sessionStorage.removeItem(cacheKey)
+      sessionStorage.removeItem(cacheKey + 'time')
+    }
+  }
+
+  // Cached data was not returned so make a regular fetch() call
+  return fetch(url, init).then(response => {
+    if (response.status === 200) {
+      let contentType = response.headers.get('Content-Type')
+      // Only cache json and text data, no binary support
+      if (contentType && (contentType.match(/application\/json/i) || contentType.match(/text\//i))) {
+        response.clone().text().then(content => {
+          sessionStorage.setItem(cacheKey, content)
+          // Set the timeout time to 'timeout' milliseconds in the future
+          sessionStorage.setItem(cacheKey + 'time', Date.now() + (timeout * 1000))
+        })
+      }
+    }
+    return response
+  })
+}
+
+export default cachedFetch

--- a/tests/__snapshots__/home.test.js.snap
+++ b/tests/__snapshots__/home.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Home renders correctly 1`] = `"<div class=\\"container pt-4 pb-4\\"><section><h2>People</h2> <div class=\\"d-flex flex-wrap\\"></div></section></div>"`;
+exports[`Home renders correctly 1`] = `"<div class=\\"container pt-4 pb-4\\"><section><h2>People</h2> <div class=\\"d-flex flex-wrap\\"></div> <div class=\\"d-flex flex-row justify-content-center btn-group\\"><button class=\\"btn btn-secondary disabled\\">Previous</button> <button class=\\"btn btn-secondary disabled\\">1</button> <button class=\\"btn btn-secondary disabled\\">Next</button></div></section></div>"`;

--- a/tests/__snapshots__/home.test.js.snap
+++ b/tests/__snapshots__/home.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Home renders correctly 1`] = `"<div class=\\"container pt-4 pb-4\\"><section><h2>People</h2> <div class=\\"d-flex flex-wrap\\"></div> <div class=\\"d-flex flex-row justify-content-center btn-group\\"><button class=\\"btn btn-secondary disabled\\">Previous</button> <button class=\\"btn btn-secondary disabled\\">1</button> <button class=\\"btn btn-secondary disabled\\">Next</button></div></section></div>"`;
+exports[`Home renders correctly 1`] = `"<div class=\\"container pt-4 pb-4\\"><section><h2>People</h2> <div class=\\"d-flex flex-wrap\\"></div> <div class=\\"d-flex flex-row justify-content-center btn-group\\"><button id=\\"previousPage\\" class=\\"btn btn-secondary disabled\\">Previous</button> <button id=\\"pageNumber\\" class=\\"btn btn-secondary disabled\\">1</button> <button id=\\"nextPage\\" class=\\"btn btn-secondary disabled\\">Next</button></div></section></div>"`;

--- a/tests/cachedFetch.test.js
+++ b/tests/cachedFetch.test.js
@@ -1,0 +1,55 @@
+import cachedFetch from '../src/util/cachedFetch'
+
+beforeEach(() => {
+  // fetch is mocked and returns fake data
+  global.fetch = jest.fn().mockImplementation(() => {
+    return new Promise((resolve, reject) => {
+      resolve({
+        ok: true,
+        json: function() {
+          return 'fake'
+        }
+      });
+    });
+  });
+
+  // sessionStorage is not available in Jest so it must be mocked
+  global.sessionStorage = jest.fn();
+  global.sessionStorage.setItem = jest.fn();
+  global.sessionStorage.getItem = jest.fn();
+  global.sessionStorage.removeItem = jest.fn();
+})
+
+it('should make fetch call by default', () => {
+  cachedFetch('www.test.com')
+
+  expect(global.fetch).toHaveBeenCalledTimes(1)
+})
+
+it('should use cache when available', () => {
+  // getItem is mocked to return fake data or a time 10 seconds in the future
+  // for items with time in the name
+  global.sessionStorage.getItem = jest.fn().mockImplementation((key) => {
+    return key.includes('time') ? Date.now() + 10000 : 'fake'
+  });
+
+  // Response is not available in Jest so mock it also, no implementation necessary
+  global.Response = jest.fn()
+
+  cachedFetch('www.test.com')
+
+  expect(global.fetch).toHaveBeenCalledTimes(0)
+})
+
+it('should not use cache when data is expired', () => {
+  // Time 1 second in the past
+  global.sessionStorage.getItem = jest.fn().mockImplementation((key) => {
+    return key.includes('time') ? Date.now() - 1000 : 'fake'
+  });
+
+  global.Response = jest.fn()
+
+  cachedFetch('www.test.com')
+
+  expect(global.fetch).toHaveBeenCalledTimes(1)
+})

--- a/tests/home.test.js
+++ b/tests/home.test.js
@@ -12,3 +12,83 @@ test('Home renders correctly', () => {
   const wrapper = mount(Home, { store, localVue })
   expect(wrapper.html()).toMatchSnapshot()
 })
+
+describe('pagination', () => {
+  let store, actions, state
+
+  // Create new Vuex store with modified state
+  const modifyState = (newState) => {
+    new Vuex.Store({
+      modules: {
+        people: {
+          ...Object.assign(state, newState),
+          actions,
+          namespaced: true
+        }
+      }
+    })
+  }
+
+  // Create mock Vuex store with default state and mock actions
+  beforeEach(() => {
+    state = {
+      page: 1,
+      next: null,
+      previous: null,
+      results: []
+    }
+    actions = {
+      list: jest.fn()
+    }
+    store = new Vuex.Store({
+      modules: {
+        people: {
+          state,
+          actions,
+          namespaced: true
+        }
+      }
+    })
+  })
+
+  it('should render page number', () => {
+    modifyState({page: 3})
+    const wrapper = mount(Home, { store, localVue })
+
+    expect(wrapper.find('#pageNumber').text()).toBe('3')
+  })
+
+  it('should render first page with previous and next disabled', () => {
+    const wrapper = mount(Home, { store, localVue })
+
+    const previousButton = wrapper.find('#previousPage')
+    const nextButton = wrapper.find('#nextPage')
+
+    expect(previousButton.classes()).toContain('disabled')
+    expect(nextButton.classes()).toContain('disabled')
+  })
+
+  it('should render first page with next enabled given non-null next', () => {
+    modifyState({next: "https://swapi.co/api/people/?page=2"})
+
+    const wrapper = mount(Home, { store, localVue })
+
+    const previousButton = wrapper.find('#previousPage')
+    const nextButton = wrapper.find('#nextPage')
+
+    expect(previousButton.classes()).toContain('disabled')
+    expect(nextButton.classes()).not.toContain('disabled')
+  })
+
+  it('should render last page with disabled next button', () => {
+    modifyState({page: 2, previous: "https://swapi.co/api/people/?page=1"})
+
+    const wrapper = mount(Home, { store, localVue })
+
+    const previousButton = wrapper.find('#previousPage')
+    const nextButton = wrapper.find('#nextPage')
+
+    expect(previousButton.classes()).not.toContain('disabled')
+    expect(nextButton.classes()).toContain('disabled')
+  })
+})


### PR DESCRIPTION
This adds pagination to the People page. Next/Previous buttons are driven off API request. Current page, and next and previous links are persisted the store. This required some rework of the people actions and mutations. Buttons are dynamically disabled and they are styled using Bootstrap button groups.

Also, this adds a util function, cachedFetch. It is a wrapper for fetch that stores responses and their expiry time in sessionStorage. I chose session over local storage because there is no functionality to clean up expired caches. Everything will get removed when the session ends which I think is fine with such a short expiry time.

There are fairly robust unit tests for each of these. They could be better/more readable if I took the time to setup more global mocks and perhaps some manual mocks for pieces of the app. I could also include some node modules that could help mock things like Vuex and fetch.

This was an interesting assignment with a good mix of problems. I've never worked with Vue.js before but I have used Jest extensively, maybe you can tell.